### PR TITLE
Add initial Rust module structure and scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Environment and secrets
+.env
+.env.local
+.env*.local
+
+# Agent instructions (contains project-specific guidance)
+claude.md
+CLAUDE.md
+
+# Rust build artifacts
+/target/
+**/*.rs.bk
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test artifacts
+*.log
+/test-output/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "optical-entropy"
+version = "0.1.0"
+edition = "2021"
+authors = ["Optical Entropy Contributors"]
+description = "Physical entropy source using optical phenomena for CSPRNG reseeding"
+license = "MIT"
+repository = "https://github.com/yourusername/optical-entropy-generation"
+readme = "README.md"
+keywords = ["entropy", "cryptography", "random", "csprng"]
+categories = ["cryptography", "hardware-support"]
+
+[dependencies]
+# Cryptographic primitives (well-established, audited)
+blake3 = "1.5"
+sha2 = "0.10"
+rand_chacha = "0.3"
+rand_core = "0.6"
+
+# Camera capture (platform abstraction)
+nokhwa = { version = "0.10", features = ["input-native"], optional = true }
+
+# Serialization and configuration
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+
+# Logging and diagnostics
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Error handling
+thiserror = "1.0"
+
+# Time handling
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+# Testing utilities
+proptest = "1.4"
+criterion = "0.5"
+
+[features]
+default = []
+camera = ["nokhwa"]
+
+[[bin]]
+name = "optical-entropy"
+path = "src/main.rs"
+
+[lib]
+name = "optical_entropy"
+path = "src/lib.rs"
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/src/analysis/health.rs
+++ b/src/analysis/health.rs
@@ -1,0 +1,193 @@
+//! Entropy health monitoring.
+//!
+//! Tracks entropy quality over time and implements fail-closed
+//! behavior when quality degrades.
+
+use super::{
+    statistics::StatisticalTests,
+    threshold::{QualityThresholds, ThresholdViolation},
+};
+use crate::extraction::RawBits;
+
+/// Current health status of the entropy source.
+#[derive(Debug, Clone)]
+pub struct HealthMetrics {
+    /// Most recent statistical test results.
+    pub latest_stats: Option<StatisticalTests>,
+    /// Whether the source is currently healthy.
+    pub is_healthy: bool,
+    /// Most recent violation, if any.
+    pub last_violation: Option<ThresholdViolation>,
+    /// Consecutive healthy samples.
+    pub consecutive_healthy: u64,
+    /// Consecutive unhealthy samples.
+    pub consecutive_unhealthy: u64,
+    /// Total samples analyzed.
+    pub total_samples: u64,
+}
+
+impl Default for HealthMetrics {
+    fn default() -> Self {
+        Self {
+            latest_stats: None,
+            is_healthy: false, // Fail-closed: unhealthy until proven otherwise
+            last_violation: None,
+            consecutive_healthy: 0,
+            consecutive_unhealthy: 0,
+            total_samples: 0,
+        }
+    }
+}
+
+/// Monitors entropy health over time.
+///
+/// Implements fail-closed behavior: reseeding is only allowed
+/// when the source has demonstrated consistent quality.
+pub struct HealthMonitor {
+    /// Quality thresholds.
+    thresholds: QualityThresholds,
+    /// Current metrics.
+    metrics: HealthMetrics,
+    /// Required consecutive healthy samples to become healthy.
+    required_healthy_streak: u64,
+}
+
+impl HealthMonitor {
+    /// Creates a new health monitor with default settings.
+    pub fn new(thresholds: QualityThresholds) -> Self {
+        Self {
+            thresholds,
+            metrics: HealthMetrics::default(),
+            required_healthy_streak: 3, // Require 3 good samples
+        }
+    }
+
+    /// Creates a monitor with a custom healthy streak requirement.
+    pub fn with_streak_requirement(thresholds: QualityThresholds, streak: u64) -> Self {
+        Self {
+            thresholds,
+            metrics: HealthMetrics::default(),
+            required_healthy_streak: streak.max(1),
+        }
+    }
+
+    /// Analyzes a sample and updates health status.
+    pub fn analyze(&mut self, raw: &RawBits) -> &HealthMetrics {
+        let stats = StatisticalTests::analyze(raw);
+        self.metrics.total_samples += 1;
+
+        match self.thresholds.check(&stats) {
+            Ok(()) => {
+                self.metrics.consecutive_healthy += 1;
+                self.metrics.consecutive_unhealthy = 0;
+                self.metrics.last_violation = None;
+
+                // Become healthy after sufficient streak
+                if self.metrics.consecutive_healthy >= self.required_healthy_streak {
+                    if !self.metrics.is_healthy {
+                        tracing::info!(
+                            streak = self.metrics.consecutive_healthy,
+                            "Entropy source became healthy"
+                        );
+                    }
+                    self.metrics.is_healthy = true;
+                }
+
+                tracing::trace!(
+                    bias = stats.bit_bias,
+                    variance = stats.variance,
+                    autocorr = stats.autocorrelation,
+                    "Health check passed"
+                );
+            }
+            Err(violation) => {
+                self.metrics.consecutive_unhealthy += 1;
+                self.metrics.consecutive_healthy = 0;
+                self.metrics.last_violation = Some(violation.clone());
+
+                // Immediately become unhealthy (fail-closed)
+                if self.metrics.is_healthy {
+                    tracing::warn!(
+                        violation = %violation,
+                        "Entropy source became unhealthy"
+                    );
+                }
+                self.metrics.is_healthy = false;
+            }
+        }
+
+        self.metrics.latest_stats = Some(stats);
+        &self.metrics
+    }
+
+    /// Returns current health metrics.
+    pub fn metrics(&self) -> &HealthMetrics {
+        &self.metrics
+    }
+
+    /// Returns true if reseeding should be allowed.
+    pub fn allow_reseed(&self) -> bool {
+        self.metrics.is_healthy
+    }
+
+    /// Resets the monitor to initial state.
+    pub fn reset(&mut self) {
+        self.metrics = HealthMetrics::default();
+        tracing::info!("Health monitor reset");
+    }
+}
+
+impl Default for HealthMonitor {
+    fn default() -> Self {
+        Self::new(QualityThresholds::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_good_data() -> RawBits {
+        let data: Vec<u8> = (0..1000).map(|i| (i * 17 + 31) as u8).collect();
+        RawBits::from_bytes(data, 1)
+    }
+
+    fn make_bad_data() -> RawBits {
+        RawBits::from_bytes(vec![0xFFu8; 1000], 1)
+    }
+
+    #[test]
+    fn test_starts_unhealthy() {
+        let monitor = HealthMonitor::new(QualityThresholds::permissive());
+        assert!(!monitor.allow_reseed());
+    }
+
+    #[test]
+    fn test_becomes_healthy_after_streak() {
+        let mut monitor =
+            HealthMonitor::with_streak_requirement(QualityThresholds::permissive(), 2);
+
+        // First good sample: not healthy yet
+        monitor.analyze(&make_good_data());
+        assert!(!monitor.allow_reseed());
+
+        // Second good sample: now healthy
+        monitor.analyze(&make_good_data());
+        assert!(monitor.allow_reseed());
+    }
+
+    #[test]
+    fn test_immediately_unhealthy_on_failure() {
+        let mut monitor =
+            HealthMonitor::with_streak_requirement(QualityThresholds::permissive(), 2);
+
+        // Become healthy
+        monitor.analyze(&make_good_data());
+        monitor.analyze(&make_good_data());
+        assert!(monitor.allow_reseed());
+
+        // Single bad sample makes unhealthy (fail-closed)
+        monitor.analyze(&make_bad_data());
+        assert!(!monitor.allow_reseed());
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,0 +1,13 @@
+//! Entropy testing and health monitoring.
+//!
+//! This module provides statistical tests and health metrics
+//! for monitoring entropy quality. These are sanity checks,
+//! not cryptographic proofs of entropy.
+
+mod health;
+mod statistics;
+mod threshold;
+
+pub use health::{HealthMetrics, HealthMonitor};
+pub use statistics::StatisticalTests;
+pub use threshold::{QualityThresholds, ThresholdViolation};

--- a/src/analysis/statistics.rs
+++ b/src/analysis/statistics.rs
@@ -1,0 +1,124 @@
+//! Statistical tests for entropy quality.
+//!
+//! These tests are sanity checks to detect obvious problems,
+//! not proofs of entropy quality. Passing these tests is necessary
+//! but not sufficient for good entropy.
+
+use crate::extraction::RawBits;
+
+/// Statistical test results.
+#[derive(Debug, Clone)]
+pub struct StatisticalTests {
+    /// Bit bias (deviation from 0.5).
+    pub bit_bias: f64,
+    /// Byte-level variance.
+    pub variance: f64,
+    /// Lag-1 autocorrelation.
+    pub autocorrelation: f64,
+    /// Number of bytes analyzed.
+    pub sample_size: usize,
+}
+
+impl StatisticalTests {
+    /// Runs all statistical tests on the raw bits.
+    pub fn analyze(raw: &RawBits) -> Self {
+        let data = raw.data();
+
+        Self {
+            bit_bias: raw.bit_bias(),
+            variance: Self::compute_variance(data),
+            autocorrelation: Self::compute_autocorrelation(data),
+            sample_size: data.len(),
+        }
+    }
+
+    /// Computes the variance of byte values.
+    fn compute_variance(data: &[u8]) -> f64 {
+        if data.is_empty() {
+            return 0.0;
+        }
+
+        let n = data.len() as f64;
+        let mean: f64 = data.iter().map(|&b| b as f64).sum::<f64>() / n;
+        let variance: f64 = data.iter().map(|&b| (b as f64 - mean).powi(2)).sum::<f64>() / n;
+
+        variance
+    }
+
+    /// Computes lag-1 autocorrelation.
+    ///
+    /// Measures correlation between consecutive bytes.
+    /// High values indicate predictable patterns.
+    fn compute_autocorrelation(data: &[u8]) -> f64 {
+        if data.len() < 2 {
+            return 0.0;
+        }
+
+        let n = data.len() as f64;
+        let mean: f64 = data.iter().map(|&b| b as f64).sum::<f64>() / n;
+
+        let variance: f64 = data.iter().map(|&b| (b as f64 - mean).powi(2)).sum::<f64>();
+
+        if variance == 0.0 {
+            return 1.0; // All same value = perfect correlation
+        }
+
+        let covariance: f64 = data
+            .windows(2)
+            .map(|w| (w[0] as f64 - mean) * (w[1] as f64 - mean))
+            .sum();
+
+        covariance / variance
+    }
+
+    /// Returns true if results look reasonable (not proof of quality).
+    pub fn looks_reasonable(&self) -> bool {
+        // These are loose sanity checks, not security guarantees
+        let bias_ok = self.bit_bias.abs() < 0.1; // Within 10% of unbiased
+        let variance_ok = self.variance > 100.0; // Some variation expected
+        let autocorr_ok = self.autocorrelation.abs() < 0.5; // Not highly correlated
+
+        bias_ok && variance_ok && autocorr_ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_uniform_random_passes() {
+        // Simulated "random" data (alternating pattern for predictability)
+        let data: Vec<u8> = (0..1000).map(|i| (i * 17 + 31) as u8).collect();
+        let raw = RawBits::from_bytes(data, 1);
+
+        let stats = StatisticalTests::analyze(&raw);
+
+        // Pseudo-random should have reasonable variance
+        assert!(stats.variance > 100.0);
+    }
+
+    #[test]
+    fn test_constant_data_fails() {
+        let data = vec![0x80u8; 1000];
+        let raw = RawBits::from_bytes(data, 1);
+
+        let stats = StatisticalTests::analyze(&raw);
+
+        // Constant data: zero variance, perfect autocorrelation
+        assert_eq!(stats.variance, 0.0);
+        assert!(!stats.looks_reasonable());
+    }
+
+    #[test]
+    fn test_all_ones_biased() {
+        let data = vec![0xFFu8; 1000];
+        let raw = RawBits::from_bytes(data, 1);
+
+        let stats = StatisticalTests::analyze(&raw);
+
+        // All ones = maximum positive bias
+        assert!((stats.bit_bias - 0.5).abs() < 0.001);
+        assert!(!stats.looks_reasonable());
+    }
+}

--- a/src/analysis/threshold.rs
+++ b/src/analysis/threshold.rs
@@ -1,0 +1,133 @@
+//! Quality thresholds for fail-closed behavior.
+//!
+//! Defines thresholds that trigger suspension of reseeding
+//! when entropy quality degrades.
+
+use super::statistics::StatisticalTests;
+use serde::{Deserialize, Serialize};
+
+/// Quality thresholds for entropy monitoring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityThresholds {
+    /// Maximum acceptable bit bias (absolute value).
+    pub max_bit_bias: f64,
+    /// Minimum acceptable variance.
+    pub min_variance: f64,
+    /// Maximum acceptable autocorrelation (absolute value).
+    pub max_autocorrelation: f64,
+}
+
+impl Default for QualityThresholds {
+    fn default() -> Self {
+        Self {
+            max_bit_bias: 0.05,       // 5% bias tolerance
+            min_variance: 500.0,      // Require meaningful variation
+            max_autocorrelation: 0.3, // Low correlation tolerance
+        }
+    }
+}
+
+impl QualityThresholds {
+    /// Creates more conservative thresholds.
+    pub fn conservative() -> Self {
+        Self {
+            max_bit_bias: 0.02,
+            min_variance: 1000.0,
+            max_autocorrelation: 0.1,
+        }
+    }
+
+    /// Creates more permissive thresholds (for testing).
+    pub fn permissive() -> Self {
+        Self {
+            max_bit_bias: 0.2,
+            min_variance: 100.0,
+            max_autocorrelation: 0.5,
+        }
+    }
+
+    /// Checks statistics against thresholds.
+    pub fn check(&self, stats: &StatisticalTests) -> Result<(), ThresholdViolation> {
+        if stats.bit_bias.abs() > self.max_bit_bias {
+            return Err(ThresholdViolation::BitBias {
+                observed: stats.bit_bias,
+                threshold: self.max_bit_bias,
+            });
+        }
+
+        if stats.variance < self.min_variance {
+            return Err(ThresholdViolation::LowVariance {
+                observed: stats.variance,
+                threshold: self.min_variance,
+            });
+        }
+
+        if stats.autocorrelation.abs() > self.max_autocorrelation {
+            return Err(ThresholdViolation::HighAutocorrelation {
+                observed: stats.autocorrelation,
+                threshold: self.max_autocorrelation,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Threshold violation types.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ThresholdViolation {
+    #[error("bit bias {observed:.4} exceeds threshold {threshold:.4}")]
+    BitBias { observed: f64, threshold: f64 },
+
+    #[error("variance {observed:.2} below threshold {threshold:.2}")]
+    LowVariance { observed: f64, threshold: f64 },
+
+    #[error("autocorrelation {observed:.4} exceeds threshold {threshold:.4}")]
+    HighAutocorrelation { observed: f64, threshold: f64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extraction::RawBits;
+
+    #[test]
+    fn test_good_data_passes() {
+        let thresholds = QualityThresholds::permissive();
+
+        // Simulated reasonable data
+        let data: Vec<u8> = (0..1000).map(|i| (i * 17 + 31) as u8).collect();
+        let raw = RawBits::from_bytes(data, 1);
+        let stats = StatisticalTests::analyze(&raw);
+
+        assert!(thresholds.check(&stats).is_ok());
+    }
+
+    #[test]
+    fn test_biased_data_fails() {
+        let thresholds = QualityThresholds::default();
+
+        let data = vec![0xFFu8; 1000]; // All ones = biased
+        let raw = RawBits::from_bytes(data, 1);
+        let stats = StatisticalTests::analyze(&raw);
+
+        assert!(matches!(
+            thresholds.check(&stats),
+            Err(ThresholdViolation::BitBias { .. })
+        ));
+    }
+
+    #[test]
+    fn test_constant_data_fails_variance() {
+        let thresholds = QualityThresholds::default();
+
+        let data = vec![0x80u8; 1000]; // Constant = zero variance
+        let raw = RawBits::from_bytes(data, 1);
+        let stats = StatisticalTests::analyze(&raw);
+
+        assert!(matches!(
+            thresholds.check(&stats),
+            Err(ThresholdViolation::LowVariance { .. })
+        ));
+    }
+}

--- a/src/capture/camera.rs
+++ b/src/capture/camera.rs
@@ -1,0 +1,126 @@
+//! Camera abstraction for frame capture.
+//!
+//! This module provides a trait-based abstraction over camera hardware,
+//! allowing for both real camera input and mock implementations for testing.
+
+use super::{CaptureConfig, Frame};
+use thiserror::Error;
+
+/// Errors that can occur during camera operations.
+#[derive(Debug, Error)]
+pub enum CameraError {
+    #[error("camera device not found: {0}")]
+    DeviceNotFound(String),
+    #[error("failed to open camera: {0}")]
+    OpenFailed(String),
+    #[error("failed to configure camera: {0}")]
+    ConfigFailed(String),
+    #[error("failed to capture frame: {0}")]
+    CaptureFailed(String),
+    #[error("camera not initialized")]
+    NotInitialized,
+}
+
+/// Trait for camera implementations.
+///
+/// This abstraction allows swapping between real camera hardware
+/// and mock implementations for testing.
+pub trait Camera {
+    /// Opens and initializes the camera with the given configuration.
+    fn open(&mut self, config: &CaptureConfig) -> Result<(), CameraError>;
+
+    /// Captures a single frame.
+    fn capture(&mut self) -> Result<Frame, CameraError>;
+
+    /// Checks if the camera is currently open.
+    fn is_open(&self) -> bool;
+
+    /// Closes the camera and releases resources.
+    fn close(&mut self);
+}
+
+/// Mock camera for testing that generates synthetic frames.
+#[derive(Debug, Default)]
+pub struct MockCamera {
+    config: Option<CaptureConfig>,
+    sequence: u64,
+}
+
+impl MockCamera {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Camera for MockCamera {
+    fn open(&mut self, config: &CaptureConfig) -> Result<(), CameraError> {
+        config
+            .validate()
+            .map_err(|e| CameraError::ConfigFailed(e.to_string()))?;
+        self.config = Some(config.clone());
+        self.sequence = 0;
+        tracing::info!("MockCamera opened with config: {:?}", config);
+        Ok(())
+    }
+
+    fn capture(&mut self) -> Result<Frame, CameraError> {
+        let config = self.config.as_ref().ok_or(CameraError::NotInitialized)?;
+
+        // Generate synthetic noise pattern for testing
+        let pixel_count = (config.width * config.height) as usize;
+        let pixels: Vec<u8> = (0..pixel_count)
+            .map(|i| {
+                // Simple deterministic pattern mixed with sequence
+                // NOT for entropy - only for testing frame handling
+                ((i as u64 ^ self.sequence) % 256) as u8
+            })
+            .collect();
+
+        self.sequence += 1;
+        Ok(Frame::new(pixels, config.width, config.height, self.sequence))
+    }
+
+    fn is_open(&self) -> bool {
+        self.config.is_some()
+    }
+
+    fn close(&mut self) {
+        self.config = None;
+        tracing::info!("MockCamera closed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mock_camera_lifecycle() {
+        let mut camera = MockCamera::new();
+        let config = CaptureConfig::default();
+
+        assert!(!camera.is_open());
+
+        camera.open(&config).unwrap();
+        assert!(camera.is_open());
+
+        let frame = camera.capture().unwrap();
+        assert!(frame.is_valid());
+        assert_eq!(frame.sequence(), 1);
+
+        let frame2 = camera.capture().unwrap();
+        assert_eq!(frame2.sequence(), 2);
+
+        camera.close();
+        assert!(!camera.is_open());
+    }
+
+    #[test]
+    fn test_capture_without_open() {
+        let mut camera = MockCamera::new();
+        assert!(matches!(
+            camera.capture(),
+            Err(CameraError::NotInitialized)
+        ));
+    }
+}

--- a/src/capture/config.rs
+++ b/src/capture/config.rs
@@ -1,0 +1,100 @@
+//! Camera capture configuration.
+//!
+//! Fixed exposure and gain settings are critical for consistent
+//! entropy characteristics. Auto-exposure would introduce
+//! unpredictable correlations.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for camera capture.
+///
+/// All settings are fixed to ensure consistent entropy characteristics.
+/// Auto-exposure and auto-gain are explicitly disabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureConfig {
+    /// Camera device index or identifier.
+    pub device_id: u32,
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Fixed exposure time in microseconds.
+    pub exposure_us: u32,
+    /// Fixed gain value (camera-specific units).
+    pub gain: u32,
+    /// Target frames per second.
+    pub fps: u32,
+    /// Use grayscale mode (recommended for entropy extraction).
+    pub grayscale: bool,
+}
+
+impl Default for CaptureConfig {
+    fn default() -> Self {
+        Self {
+            device_id: 0,
+            width: 640,
+            height: 480,
+            exposure_us: 10000, // 10ms
+            gain: 1,
+            fps: 30,
+            grayscale: true,
+        }
+    }
+}
+
+impl CaptureConfig {
+    /// Creates a new configuration with the specified dimensions.
+    pub fn with_dimensions(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            ..Default::default()
+        }
+    }
+
+    /// Validates the configuration parameters.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.width == 0 || self.height == 0 {
+            return Err(ConfigError::InvalidDimensions);
+        }
+        if self.exposure_us == 0 {
+            return Err(ConfigError::InvalidExposure);
+        }
+        if self.fps == 0 || self.fps > 120 {
+            return Err(ConfigError::InvalidFrameRate);
+        }
+        Ok(())
+    }
+}
+
+/// Configuration validation errors.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ConfigError {
+    #[error("invalid frame dimensions")]
+    InvalidDimensions,
+    #[error("invalid exposure time")]
+    InvalidExposure,
+    #[error("invalid frame rate (must be 1-120 fps)")]
+    InvalidFrameRate,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config_valid() {
+        let config = CaptureConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_zero_dimensions_invalid() {
+        let mut config = CaptureConfig::default();
+        config.width = 0;
+        assert!(matches!(
+            config.validate(),
+            Err(ConfigError::InvalidDimensions)
+        ));
+    }
+}

--- a/src/capture/frame.rs
+++ b/src/capture/frame.rs
@@ -1,0 +1,110 @@
+//! Frame type representing a captured image with metadata.
+
+use std::time::Instant;
+
+/// A single captured frame from the camera.
+///
+/// Contains raw pixel data along with metadata needed for
+/// temporal correlation analysis and debugging.
+#[derive(Clone)]
+pub struct Frame {
+    /// Raw pixel data (grayscale or RGB depending on config).
+    pixels: Vec<u8>,
+    /// Frame width in pixels.
+    width: u32,
+    /// Frame height in pixels.
+    height: u32,
+    /// Capture timestamp for temporal analysis.
+    timestamp: Instant,
+    /// Monotonic sequence number.
+    sequence: u64,
+}
+
+impl Frame {
+    /// Creates a new frame with the given parameters.
+    pub fn new(pixels: Vec<u8>, width: u32, height: u32, sequence: u64) -> Self {
+        Self {
+            pixels,
+            width,
+            height,
+            timestamp: Instant::now(),
+            sequence,
+        }
+    }
+
+    /// Returns a reference to the raw pixel data.
+    #[inline]
+    pub fn pixels(&self) -> &[u8] {
+        &self.pixels
+    }
+
+    /// Returns the frame width.
+    #[inline]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Returns the frame height.
+    #[inline]
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Returns the capture timestamp.
+    #[inline]
+    pub fn timestamp(&self) -> Instant {
+        self.timestamp
+    }
+
+    /// Returns the sequence number.
+    #[inline]
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Returns the total number of pixels (width * height).
+    #[inline]
+    pub fn pixel_count(&self) -> usize {
+        (self.width as usize) * (self.height as usize)
+    }
+
+    /// Validates that the pixel buffer size matches dimensions.
+    pub fn is_valid(&self) -> bool {
+        self.pixels.len() == self.pixel_count()
+    }
+}
+
+impl std::fmt::Debug for Frame {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Frame")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("sequence", &self.sequence)
+            .field("pixel_bytes", &self.pixels.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frame_creation() {
+        let pixels = vec![0u8; 640 * 480];
+        let frame = Frame::new(pixels, 640, 480, 1);
+
+        assert_eq!(frame.width(), 640);
+        assert_eq!(frame.height(), 480);
+        assert_eq!(frame.sequence(), 1);
+        assert!(frame.is_valid());
+    }
+
+    #[test]
+    fn test_frame_invalid_size() {
+        let pixels = vec![0u8; 100]; // Wrong size
+        let frame = Frame::new(pixels, 640, 480, 1);
+
+        assert!(!frame.is_valid());
+    }
+}

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,0 +1,13 @@
+//! Camera input and frame handling.
+//!
+//! This module provides abstractions for capturing frames from a camera
+//! and managing camera configuration. The camera is treated as a source
+//! of raw optical data, not as a source of entropy directly.
+
+mod camera;
+mod config;
+mod frame;
+
+pub use camera::{Camera, CameraError, MockCamera};
+pub use config::CaptureConfig;
+pub use frame::Frame;

--- a/src/conditioning/hash.rs
+++ b/src/conditioning/hash.rs
@@ -1,0 +1,151 @@
+//! Cryptographic hash-based entropy conditioning.
+//!
+//! Uses standard hash functions to transform biased, correlated
+//! raw bits into uniformly distributed output.
+
+use crate::extraction::RawBits;
+use blake3::Hasher as Blake3Hasher;
+use sha2::{Digest, Sha256};
+
+/// Supported hash algorithms for conditioning.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum HashAlgorithm {
+    /// BLAKE3 - fast, secure, recommended default.
+    #[default]
+    Blake3,
+    /// SHA-256 - widely deployed, conservative choice.
+    Sha256,
+}
+
+/// Conditioned entropy output.
+///
+/// Fixed-size output from the conditioning hash, ready for
+/// use as CSPRNG seed material.
+#[derive(Clone)]
+pub struct ConditionedSeed {
+    /// The conditioned bytes (32 bytes for both BLAKE3 and SHA-256).
+    data: [u8; 32],
+    /// Source entropy estimate in bits.
+    entropy_estimate: usize,
+}
+
+impl ConditionedSeed {
+    /// Returns the seed bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.data
+    }
+
+    /// Returns the entropy estimate.
+    #[inline]
+    pub fn entropy_estimate(&self) -> usize {
+        self.entropy_estimate
+    }
+}
+
+impl std::fmt::Debug for ConditionedSeed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConditionedSeed")
+            .field("entropy_estimate", &self.entropy_estimate)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Entropy conditioner using cryptographic hashing.
+///
+/// Transforms raw extracted bits into uniformly distributed
+/// seed material using a cryptographic hash function.
+pub struct Conditioner {
+    algorithm: HashAlgorithm,
+}
+
+impl Conditioner {
+    /// Creates a new conditioner with the specified algorithm.
+    pub fn new(algorithm: HashAlgorithm) -> Self {
+        Self { algorithm }
+    }
+
+    /// Conditions raw bits into a fixed-size seed.
+    ///
+    /// The entropy estimate is conservative: we assume the raw bits
+    /// contain at most 1 bit of entropy per byte of input, capped
+    /// at the output size.
+    pub fn condition(&self, raw: &RawBits) -> ConditionedSeed {
+        let data = match self.algorithm {
+            HashAlgorithm::Blake3 => {
+                let mut hasher = Blake3Hasher::new();
+                hasher.update(raw.data());
+                *hasher.finalize().as_bytes()
+            }
+            HashAlgorithm::Sha256 => {
+                let mut hasher = Sha256::new();
+                hasher.update(raw.data());
+                let result = hasher.finalize();
+                let mut data = [0u8; 32];
+                data.copy_from_slice(&result);
+                data
+            }
+        };
+
+        // Conservative entropy estimate: assume ~1 bit per input byte,
+        // but never more than output size (256 bits).
+        let entropy_estimate = raw.len().min(256);
+
+        ConditionedSeed {
+            data,
+            entropy_estimate,
+        }
+    }
+}
+
+impl Default for Conditioner {
+    fn default() -> Self {
+        Self::new(HashAlgorithm::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blake3_conditioning() {
+        let conditioner = Conditioner::new(HashAlgorithm::Blake3);
+        let raw = RawBits::from_bytes(vec![0x42; 1000], 1);
+
+        let seed = conditioner.condition(&raw);
+        assert_eq!(seed.as_bytes().len(), 32);
+        assert_eq!(seed.entropy_estimate(), 256); // capped at output size
+    }
+
+    #[test]
+    fn test_sha256_conditioning() {
+        let conditioner = Conditioner::new(HashAlgorithm::Sha256);
+        let raw = RawBits::from_bytes(vec![0x42; 1000], 1);
+
+        let seed = conditioner.condition(&raw);
+        assert_eq!(seed.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_different_input_different_output() {
+        let conditioner = Conditioner::default();
+
+        let raw1 = RawBits::from_bytes(vec![0x00; 100], 1);
+        let raw2 = RawBits::from_bytes(vec![0x01; 100], 1);
+
+        let seed1 = conditioner.condition(&raw1);
+        let seed2 = conditioner.condition(&raw2);
+
+        assert_ne!(seed1.as_bytes(), seed2.as_bytes());
+    }
+
+    #[test]
+    fn test_small_input_limited_entropy() {
+        let conditioner = Conditioner::default();
+        let raw = RawBits::from_bytes(vec![0x42; 10], 1);
+
+        let seed = conditioner.condition(&raw);
+        assert_eq!(seed.entropy_estimate(), 10); // limited by input size
+    }
+}

--- a/src/conditioning/mod.rs
+++ b/src/conditioning/mod.rs
@@ -1,0 +1,11 @@
+//! Entropy conditioning via cryptographic hashing.
+//!
+//! This module transforms raw extracted bits into uniformly distributed
+//! entropy suitable for CSPRNG reseeding. It uses well-established
+//! cryptographic hash functions to remove bias and correlations.
+
+mod hash;
+mod pool;
+
+pub use hash::{ConditionedSeed, Conditioner, HashAlgorithm};
+pub use pool::{EntropyPool, PoolConfig};

--- a/src/conditioning/pool.rs
+++ b/src/conditioning/pool.rs
@@ -1,0 +1,196 @@
+//! Entropy accumulation pool.
+//!
+//! Collects entropy from multiple extractions before conditioning,
+//! ensuring sufficient entropy has been gathered before reseeding.
+
+use super::hash::{ConditionedSeed, Conditioner, HashAlgorithm};
+use crate::extraction::RawBits;
+
+/// Configuration for the entropy pool.
+#[derive(Debug, Clone)]
+pub struct PoolConfig {
+    /// Minimum bits to accumulate before allowing extraction.
+    pub min_bits: usize,
+    /// Maximum bytes to buffer (prevents unbounded growth).
+    pub max_bytes: usize,
+    /// Hash algorithm for conditioning.
+    pub algorithm: HashAlgorithm,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            min_bits: 512,        // Require 512 bits minimum
+            max_bytes: 64 * 1024, // Cap at 64KB
+            algorithm: HashAlgorithm::Blake3,
+        }
+    }
+}
+
+/// Accumulates entropy before conditioning.
+///
+/// The pool collects raw bits from multiple extraction cycles,
+/// ensuring sufficient entropy has been gathered before producing
+/// conditioned output for reseeding.
+pub struct EntropyPool {
+    /// Accumulated raw bytes.
+    buffer: Vec<u8>,
+    /// Configuration.
+    config: PoolConfig,
+    /// Conditioner instance.
+    conditioner: Conditioner,
+    /// Total bits added (for metrics).
+    total_bits_added: u64,
+    /// Total extractions performed.
+    total_extractions: u64,
+}
+
+impl EntropyPool {
+    /// Creates a new entropy pool with the given configuration.
+    pub fn new(config: PoolConfig) -> Self {
+        let conditioner = Conditioner::new(config.algorithm);
+        Self {
+            buffer: Vec::with_capacity(config.max_bytes),
+            config,
+            conditioner,
+            total_bits_added: 0,
+            total_extractions: 0,
+        }
+    }
+
+    /// Adds raw bits to the pool.
+    pub fn add(&mut self, raw: &RawBits) {
+        let space_remaining = self.config.max_bytes.saturating_sub(self.buffer.len());
+        let bytes_to_add = raw.len().min(space_remaining);
+
+        self.buffer.extend_from_slice(&raw.data()[..bytes_to_add]);
+        self.total_bits_added += (bytes_to_add * 8) as u64;
+
+        tracing::trace!(
+            bytes_added = bytes_to_add,
+            pool_size = self.buffer.len(),
+            "Added entropy to pool"
+        );
+    }
+
+    /// Returns true if the pool has enough entropy for extraction.
+    pub fn is_ready(&self) -> bool {
+        self.buffer.len() * 8 >= self.config.min_bits
+    }
+
+    /// Extracts conditioned entropy from the pool.
+    ///
+    /// Returns `None` if insufficient entropy has been accumulated.
+    /// Clears the pool after extraction.
+    pub fn extract(&mut self) -> Option<ConditionedSeed> {
+        if !self.is_ready() {
+            tracing::debug!(
+                pool_bits = self.buffer.len() * 8,
+                min_bits = self.config.min_bits,
+                "Pool not ready for extraction"
+            );
+            return None;
+        }
+
+        let raw = RawBits::from_bytes(std::mem::take(&mut self.buffer), self.total_extractions);
+        let seed = self.conditioner.condition(&raw);
+
+        self.total_extractions += 1;
+
+        tracing::debug!(
+            extraction_number = self.total_extractions,
+            entropy_estimate = seed.entropy_estimate(),
+            "Extracted conditioned entropy"
+        );
+
+        Some(seed)
+    }
+
+    /// Returns the current pool size in bytes.
+    pub fn size_bytes(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Returns the current pool size in bits.
+    pub fn size_bits(&self) -> usize {
+        self.buffer.len() * 8
+    }
+
+    /// Returns total bits ever added to the pool.
+    pub fn total_bits_added(&self) -> u64 {
+        self.total_bits_added
+    }
+
+    /// Returns total extractions performed.
+    pub fn total_extractions(&self) -> u64 {
+        self.total_extractions
+    }
+
+    /// Clears the pool without extracting.
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+        tracing::info!("Entropy pool cleared");
+    }
+}
+
+impl Default for EntropyPool {
+    fn default() -> Self {
+        Self::new(PoolConfig::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pool_not_ready_initially() {
+        let pool = EntropyPool::default();
+        assert!(!pool.is_ready());
+    }
+
+    #[test]
+    fn test_pool_ready_after_sufficient_entropy() {
+        let config = PoolConfig {
+            min_bits: 80, // 10 bytes
+            ..Default::default()
+        };
+        let mut pool = EntropyPool::new(config);
+
+        pool.add(&RawBits::from_bytes(vec![0u8; 10], 1));
+        assert!(pool.is_ready());
+    }
+
+    #[test]
+    fn test_extraction_clears_pool() {
+        let config = PoolConfig {
+            min_bits: 80,
+            ..Default::default()
+        };
+        let mut pool = EntropyPool::new(config);
+
+        pool.add(&RawBits::from_bytes(vec![0u8; 20], 1));
+        assert!(pool.is_ready());
+
+        let seed = pool.extract();
+        assert!(seed.is_some());
+        assert!(!pool.is_ready());
+        assert_eq!(pool.size_bytes(), 0);
+    }
+
+    #[test]
+    fn test_max_bytes_limit() {
+        let config = PoolConfig {
+            min_bits: 8,
+            max_bytes: 10,
+            ..Default::default()
+        };
+        let mut pool = EntropyPool::new(config);
+
+        // Try to add more than max
+        pool.add(&RawBits::from_bytes(vec![0u8; 100], 1));
+
+        // Should be capped at max_bytes
+        assert_eq!(pool.size_bytes(), 10);
+    }
+}

--- a/src/extraction/bitstream.rs
+++ b/src/extraction/bitstream.rs
@@ -1,0 +1,113 @@
+//! Raw bitstream type for extracted entropy.
+
+/// Raw bits extracted from camera frames.
+///
+/// This is the output of the extraction stage and input to conditioning.
+/// The bits are decorrelated but not yet cryptographically processed.
+#[derive(Clone)]
+pub struct RawBits {
+    /// Raw byte data.
+    data: Vec<u8>,
+    /// Number of source frames that contributed.
+    source_frames: u64,
+}
+
+impl RawBits {
+    /// Creates a new RawBits from byte data.
+    pub fn from_bytes(data: Vec<u8>, source_frames: u64) -> Self {
+        Self {
+            data,
+            source_frames,
+        }
+    }
+
+    /// Returns the raw byte data.
+    #[inline]
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Returns the number of bytes.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns true if empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns the number of bits.
+    #[inline]
+    pub fn bit_count(&self) -> usize {
+        self.data.len() * 8
+    }
+
+    /// Returns the source frame count.
+    #[inline]
+    pub fn source_frames(&self) -> u64 {
+        self.source_frames
+    }
+
+    /// Counts the number of set bits (for bias analysis).
+    pub fn popcount(&self) -> usize {
+        self.data.iter().map(|b| b.count_ones() as usize).sum()
+    }
+
+    /// Calculates bit bias as deviation from 0.5.
+    ///
+    /// Returns a value in [-0.5, 0.5] where 0.0 is unbiased.
+    pub fn bit_bias(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        let ones = self.popcount() as f64;
+        let total = self.bit_count() as f64;
+        (ones / total) - 0.5
+    }
+}
+
+impl std::fmt::Debug for RawBits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawBits")
+            .field("bytes", &self.data.len())
+            .field("source_frames", &self.source_frames)
+            .field("bit_bias", &format!("{:.4}", self.bit_bias()))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unbiased_data() {
+        // Alternating bits: 0xAA = 10101010
+        let data = vec![0xAA; 100];
+        let bits = RawBits::from_bytes(data, 1);
+
+        // Should be perfectly unbiased
+        assert!((bits.bit_bias()).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_all_ones_bias() {
+        let data = vec![0xFF; 100];
+        let bits = RawBits::from_bytes(data, 1);
+
+        // All ones = bias of +0.5
+        assert!((bits.bit_bias() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_all_zeros_bias() {
+        let data = vec![0x00; 100];
+        let bits = RawBits::from_bytes(data, 1);
+
+        // All zeros = bias of -0.5
+        assert!((bits.bit_bias() + 0.5).abs() < 0.001);
+    }
+}

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -1,0 +1,77 @@
+//! Bit harvesting and decorrelation.
+//!
+//! This module converts raw camera frames into decorrelated bitstreams
+//! suitable for entropy conditioning. It applies temporal and spatial
+//! transformations to reduce structure and correlations in the raw data.
+
+mod bitstream;
+mod spatial;
+mod temporal;
+
+pub use bitstream::RawBits;
+pub use spatial::SpatialMixer;
+pub use temporal::TemporalDifferencer;
+
+use crate::capture::Frame;
+
+/// Extracts raw bits from a sequence of frames.
+///
+/// Combines temporal differencing and spatial mixing to produce
+/// a decorrelated bitstream from raw camera input.
+pub struct Extractor {
+    temporal: TemporalDifferencer,
+    spatial: SpatialMixer,
+}
+
+impl Extractor {
+    pub fn new() -> Self {
+        Self {
+            temporal: TemporalDifferencer::new(),
+            spatial: SpatialMixer::new(),
+        }
+    }
+
+    /// Processes a frame and returns extracted bits if ready.
+    ///
+    /// Returns `None` if more frames are needed (e.g., for differencing).
+    pub fn process(&mut self, frame: &Frame) -> Option<RawBits> {
+        // Apply temporal differencing
+        let diff = self.temporal.difference(frame)?;
+
+        // Apply spatial mixing
+        let mixed = self.spatial.mix(&diff);
+
+        Some(RawBits::from_bytes(mixed, frame.sequence()))
+    }
+
+    /// Resets internal state (e.g., after quality failure).
+    pub fn reset(&mut self) {
+        self.temporal.reset();
+    }
+}
+
+impl Default for Extractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extractor_needs_two_frames() {
+        let mut extractor = Extractor::new();
+
+        let frame1 = Frame::new(vec![100u8; 64], 8, 8, 1);
+        let frame2 = Frame::new(vec![150u8; 64], 8, 8, 2);
+
+        // First frame: no output (need previous for differencing)
+        assert!(extractor.process(&frame1).is_none());
+
+        // Second frame: should produce output
+        let bits = extractor.process(&frame2);
+        assert!(bits.is_some());
+    }
+}

--- a/src/extraction/spatial.rs
+++ b/src/extraction/spatial.rs
@@ -1,0 +1,96 @@
+//! Spatial decorrelation via pixel mixing.
+//!
+//! Reduces spatial correlations (adjacent pixel similarity) by
+//! XORing pixels from different regions of the frame.
+
+/// Mixes pixels spatially to reduce local correlations.
+///
+/// Adjacent pixels in camera images are often correlated.
+/// This mixer XORs pixels from distant regions to break
+/// spatial structure.
+pub struct SpatialMixer {
+    /// Mixing stride (pixels apart to XOR).
+    stride: usize,
+}
+
+impl SpatialMixer {
+    pub fn new() -> Self {
+        Self { stride: 1 }
+    }
+
+    /// Creates a mixer with a custom stride.
+    pub fn with_stride(stride: usize) -> Self {
+        Self {
+            stride: stride.max(1),
+        }
+    }
+
+    /// Mixes the input data spatially.
+    ///
+    /// XORs each byte with a byte `stride` positions away,
+    /// wrapping around at boundaries.
+    pub fn mix(&self, data: &[u8]) -> Vec<u8> {
+        if data.is_empty() {
+            return Vec::new();
+        }
+
+        let len = data.len();
+        let stride = self.stride % len.max(1);
+
+        data.iter()
+            .enumerate()
+            .map(|(i, &byte)| {
+                let partner_idx = (i + stride) % len;
+                byte ^ data[partner_idx]
+            })
+            .collect()
+    }
+}
+
+impl Default for SpatialMixer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_input() {
+        let mixer = SpatialMixer::new();
+        assert!(mixer.mix(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_self_xor_with_stride_zero() {
+        // With stride 0 (treated as 1), each byte XORs with next
+        let mixer = SpatialMixer::with_stride(0);
+        let data = vec![0xAA, 0x55, 0xAA, 0x55];
+        let result = mixer.mix(&data);
+
+        // 0xAA ^ 0x55 = 0xFF for all positions
+        assert!(result.iter().all(|&v| v == 0xFF));
+    }
+
+    #[test]
+    fn test_identical_data_zeros() {
+        let mixer = SpatialMixer::new();
+        let data = vec![0x42; 100];
+        let result = mixer.mix(&data);
+
+        // Identical bytes XOR to zero
+        assert!(result.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn test_varied_data_nonzero() {
+        let mixer = SpatialMixer::with_stride(7);
+        let data: Vec<u8> = (0..100).collect();
+        let result = mixer.mix(&data);
+
+        // Should produce non-zero output for varied input
+        assert!(result.iter().any(|&v| v != 0));
+    }
+}

--- a/src/extraction/temporal.rs
+++ b/src/extraction/temporal.rs
@@ -1,0 +1,112 @@
+//! Temporal decorrelation via frame differencing.
+//!
+//! Removes static patterns by computing differences between
+//! consecutive frames. Only changes between frames contribute
+//! to the output, reducing the impact of fixed-pattern noise.
+
+use crate::capture::Frame;
+
+/// Computes differences between consecutive frames.
+///
+/// This reduces static patterns (dead pixels, fixed noise) and
+/// emphasizes temporal changes in the optical signal.
+pub struct TemporalDifferencer {
+    /// Previous frame for differencing.
+    previous: Option<Frame>,
+}
+
+impl TemporalDifferencer {
+    pub fn new() -> Self {
+        Self { previous: None }
+    }
+
+    /// Computes the absolute difference with the previous frame.
+    ///
+    /// Returns `None` on the first frame (no previous to compare).
+    pub fn difference(&mut self, current: &Frame) -> Option<Vec<u8>> {
+        let result = self.previous.as_ref().map(|prev| {
+            // Compute absolute difference pixel by pixel
+            current
+                .pixels()
+                .iter()
+                .zip(prev.pixels().iter())
+                .map(|(&c, &p)| c.abs_diff(p))
+                .collect()
+        });
+
+        // Store current as previous for next call
+        self.previous = Some(current.clone());
+
+        result
+    }
+
+    /// Resets the differencer state.
+    pub fn reset(&mut self) {
+        self.previous = None;
+    }
+
+    /// Returns true if ready to produce output.
+    pub fn is_primed(&self) -> bool {
+        self.previous.is_some()
+    }
+}
+
+impl Default for TemporalDifferencer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_frame_returns_none() {
+        let mut diff = TemporalDifferencer::new();
+        let frame = Frame::new(vec![100u8; 64], 8, 8, 1);
+
+        assert!(diff.difference(&frame).is_none());
+        assert!(diff.is_primed());
+    }
+
+    #[test]
+    fn test_second_frame_returns_difference() {
+        let mut diff = TemporalDifferencer::new();
+
+        let frame1 = Frame::new(vec![100u8; 64], 8, 8, 1);
+        let frame2 = Frame::new(vec![150u8; 64], 8, 8, 2);
+
+        diff.difference(&frame1);
+        let result = diff.difference(&frame2).unwrap();
+
+        // All pixels should have difference of 50
+        assert!(result.iter().all(|&v| v == 50));
+    }
+
+    #[test]
+    fn test_identical_frames_zero_difference() {
+        let mut diff = TemporalDifferencer::new();
+
+        let frame1 = Frame::new(vec![100u8; 64], 8, 8, 1);
+        let frame2 = Frame::new(vec![100u8; 64], 8, 8, 2);
+
+        diff.difference(&frame1);
+        let result = diff.difference(&frame2).unwrap();
+
+        // Identical frames = zero difference
+        assert!(result.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn test_reset_requires_new_prime() {
+        let mut diff = TemporalDifferencer::new();
+
+        let frame = Frame::new(vec![100u8; 64], 8, 8, 1);
+        diff.difference(&frame);
+        assert!(diff.is_primed());
+
+        diff.reset();
+        assert!(!diff.is_primed());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,80 @@
+//! Optical Entropy Generation Library
+//!
+//! A physical entropy source using optical phenomena and camera capture.
+//! Provides conditioned entropy for reseeding cryptographically secure
+//! pseudorandom number generators (CSPRNGs).
+//!
+//! # Architecture
+//!
+//! The system follows an explicit data flow:
+//!
+//! ```text
+//! capture → extraction → conditioning → reseeding
+//!     ↓          ↓            ↓
+//!           analysis (health monitoring)
+//! ```
+//!
+//! # Design Principles
+//!
+//! - **Fail-closed**: Reseeding is suspended if entropy quality degrades
+//! - **Supplements OS entropy**: Does not replace system randomness
+//! - **Uses standard primitives**: BLAKE3/SHA-256 for conditioning, ChaCha20 for CSPRNG
+//! - **No cryptographic claims**: Statistical tests are sanity checks, not proofs
+//!
+//! # Example
+//!
+//! ```no_run
+//! use optical_entropy::{
+//!     capture::{MockCamera, Camera, CaptureConfig},
+//!     extraction::Extractor,
+//!     conditioning::EntropyPool,
+//!     analysis::HealthMonitor,
+//!     reseeding::ReseedableRng,
+//! };
+//!
+//! // Initialize components
+//! let mut camera = MockCamera::new();
+//! camera.open(&CaptureConfig::default()).unwrap();
+//!
+//! let mut extractor = Extractor::new();
+//! let mut pool = EntropyPool::default();
+//! let mut health = HealthMonitor::default();
+//! let mut rng = ReseedableRng::from_os_entropy();
+//!
+//! // Capture and process frames
+//! for _ in 0..10 {
+//!     let frame = camera.capture().unwrap();
+//!
+//!     if let Some(bits) = extractor.process(&frame) {
+//!         health.analyze(&bits);
+//!         pool.add(&bits);
+//!     }
+//! }
+//!
+//! // Reseed if healthy and pool is ready
+//! if health.allow_reseed() {
+//!     if let Some(seed) = pool.extract() {
+//!         rng.reseed(&seed).unwrap();
+//!     }
+//! }
+//! ```
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![deny(unsafe_code)]
+
+pub mod analysis;
+pub mod capture;
+pub mod conditioning;
+pub mod extraction;
+pub mod reseeding;
+
+// Re-export commonly used types at crate root
+pub use analysis::{HealthMetrics, HealthMonitor, QualityThresholds};
+pub use capture::{Camera, CaptureConfig, Frame, MockCamera};
+pub use conditioning::{Conditioner, ConditionedSeed, EntropyPool, HashAlgorithm};
+pub use extraction::{Extractor, RawBits};
+pub use reseeding::ReseedableRng;
+
+/// Library version.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,112 @@
+//! Optical Entropy Generation CLI
+//!
+//! Command-line interface for testing and demonstrating the optical
+//! entropy generation system.
+
+use optical_entropy::{
+    analysis::HealthMonitor,
+    capture::{Camera, CaptureConfig, MockCamera},
+    conditioning::EntropyPool,
+    extraction::Extractor,
+    reseeding::ReseedableRng,
+};
+use rand_core::RngCore;
+use tracing::{info, warn};
+
+fn main() {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .init();
+
+    info!("Optical Entropy Generator v{}", optical_entropy::VERSION);
+    info!("This is a demonstration using mock camera input");
+
+    // Initialize components
+    let config = CaptureConfig::default();
+    let mut camera = MockCamera::new();
+
+    if let Err(e) = camera.open(&config) {
+        eprintln!("Failed to open camera: {}", e);
+        std::process::exit(1);
+    }
+
+    let mut extractor = Extractor::new();
+    let mut pool = EntropyPool::default();
+    let mut health = HealthMonitor::default();
+    let mut rng = ReseedableRng::from_os_entropy();
+
+    info!("Processing frames...");
+
+    // Process frames
+    let frame_count = 20;
+    let mut healthy_count = 0;
+    let mut unhealthy_count = 0;
+
+    for i in 0..frame_count {
+        let frame = match camera.capture() {
+            Ok(f) => f,
+            Err(e) => {
+                warn!("Frame capture failed: {}", e);
+                continue;
+            }
+        };
+
+        if let Some(bits) = extractor.process(&frame) {
+            let metrics = health.analyze(&bits);
+
+            if metrics.is_healthy {
+                healthy_count += 1;
+                pool.add(&bits);
+            } else {
+                unhealthy_count += 1;
+                if let Some(ref violation) = metrics.last_violation {
+                    warn!("Frame {}: quality violation: {}", i, violation);
+                }
+            }
+        }
+    }
+
+    info!(
+        "Processed {} frames: {} healthy, {} unhealthy",
+        frame_count, healthy_count, unhealthy_count
+    );
+
+    // Attempt reseeding
+    if health.allow_reseed() && pool.is_ready() {
+        if let Some(seed) = pool.extract() {
+            match rng.reseed(&seed) {
+                Ok(()) => {
+                    info!(
+                        "CSPRNG reseeded successfully (entropy estimate: {} bits)",
+                        seed.entropy_estimate()
+                    );
+                }
+                Err(e) => {
+                    warn!("Reseed failed: {}", e);
+                }
+            }
+        }
+    } else {
+        warn!("Reseeding not performed: health={}, pool_ready={}",
+            health.allow_reseed(), pool.is_ready());
+    }
+
+    // Generate some random output to demonstrate
+    info!("Generating sample random output:");
+    let mut output = [0u8; 32];
+    rng.fill_bytes(&mut output);
+
+    println!(
+        "Random bytes: {}",
+        output
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
+    );
+
+    info!("Done. Reseed count: {}", rng.reseed_count());
+}

--- a/src/reseeding/csprng.rs
+++ b/src/reseeding/csprng.rs
@@ -1,0 +1,173 @@
+//! ChaCha-based CSPRNG with reseeding support.
+//!
+//! Wraps the standard ChaCha20 CSPRNG with an interface for
+//! reseeding from conditioned optical entropy.
+
+use crate::conditioning::ConditionedSeed;
+use rand_chacha::ChaCha20Rng;
+use rand_core::{RngCore, SeedableRng};
+use thiserror::Error;
+
+/// Errors that can occur during reseeding.
+#[derive(Debug, Error)]
+pub enum ReseedingError {
+    #[error("insufficient entropy: got {got} bits, need {need} bits")]
+    InsufficientEntropy { got: usize, need: usize },
+}
+
+/// A reseedable CSPRNG backed by ChaCha20.
+///
+/// This wraps the standard ChaCha20Rng with an interface designed
+/// for periodic reseeding from optical entropy. The CSPRNG is
+/// initialized from OS entropy and can be reseeded with conditioned
+/// optical entropy to supplement (not replace) the initial seed.
+pub struct ReseedableRng {
+    /// The underlying ChaCha20 CSPRNG.
+    inner: ChaCha20Rng,
+    /// Minimum entropy required for reseeding.
+    min_entropy_bits: usize,
+    /// Total reseeds performed.
+    reseed_count: u64,
+    /// Bytes generated since last reseed.
+    bytes_since_reseed: u64,
+}
+
+impl ReseedableRng {
+    /// Creates a new CSPRNG seeded from the OS entropy source.
+    ///
+    /// This is the recommended way to initialize the CSPRNG.
+    /// Optical entropy is used to *supplement* this initial seed,
+    /// not replace it.
+    pub fn from_os_entropy() -> Self {
+        Self {
+            inner: ChaCha20Rng::from_entropy(),
+            min_entropy_bits: 128,
+            reseed_count: 0,
+            bytes_since_reseed: 0,
+        }
+    }
+
+    /// Creates a CSPRNG with a specific minimum entropy requirement.
+    pub fn with_min_entropy(min_entropy_bits: usize) -> Self {
+        Self {
+            min_entropy_bits,
+            ..Self::from_os_entropy()
+        }
+    }
+
+    /// Reseeds the CSPRNG with conditioned optical entropy.
+    ///
+    /// The new seed is mixed with the current state rather than
+    /// replacing it entirely, ensuring that compromising the
+    /// optical source alone cannot predict outputs.
+    pub fn reseed(&mut self, seed: &ConditionedSeed) -> Result<(), ReseedingError> {
+        if seed.entropy_estimate() < self.min_entropy_bits {
+            return Err(ReseedingError::InsufficientEntropy {
+                got: seed.entropy_estimate(),
+                need: self.min_entropy_bits,
+            });
+        }
+
+        // Mix new seed with current state by XORing
+        // This ensures optical entropy supplements, not replaces
+        let mut current_state = [0u8; 32];
+        self.inner.fill_bytes(&mut current_state);
+
+        let mut mixed_seed = [0u8; 32];
+        for i in 0..32 {
+            mixed_seed[i] = current_state[i] ^ seed.as_bytes()[i];
+        }
+
+        self.inner = ChaCha20Rng::from_seed(mixed_seed);
+        self.reseed_count += 1;
+        self.bytes_since_reseed = 0;
+
+        tracing::info!(
+            reseed_count = self.reseed_count,
+            entropy_estimate = seed.entropy_estimate(),
+            "CSPRNG reseeded"
+        );
+
+        Ok(())
+    }
+
+    /// Returns the number of reseeds performed.
+    pub fn reseed_count(&self) -> u64 {
+        self.reseed_count
+    }
+
+    /// Returns bytes generated since last reseed.
+    pub fn bytes_since_reseed(&self) -> u64 {
+        self.bytes_since_reseed
+    }
+}
+
+impl RngCore for ReseedableRng {
+    fn next_u32(&mut self) -> u32 {
+        self.bytes_since_reseed += 4;
+        self.inner.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.bytes_since_reseed += 8;
+        self.inner.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.bytes_since_reseed += dest.len() as u64;
+        self.inner.fill_bytes(dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.bytes_since_reseed += dest.len() as u64;
+        self.inner.try_fill_bytes(dest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_seed(entropy: usize) -> ConditionedSeed {
+        // Create a seed with specified entropy estimate
+        // This is a test helper - in production, seeds come from conditioning
+        let data = [0x42u8; 32];
+        // Use a simple struct construction for testing
+        unsafe { std::mem::transmute((data, entropy)) }
+    }
+
+    #[test]
+    fn test_reseed_increments_count() {
+        let mut rng = ReseedableRng::with_min_entropy(64);
+        assert_eq!(rng.reseed_count(), 0);
+
+        // Create a mock seed with sufficient entropy
+        let seed = make_test_seed(128);
+        rng.reseed(&seed).unwrap();
+
+        assert_eq!(rng.reseed_count(), 1);
+    }
+
+    #[test]
+    fn test_insufficient_entropy_rejected() {
+        let mut rng = ReseedableRng::with_min_entropy(256);
+
+        let seed = make_test_seed(128);
+        let result = rng.reseed(&seed);
+
+        assert!(matches!(
+            result,
+            Err(ReseedingError::InsufficientEntropy { .. })
+        ));
+    }
+
+    #[test]
+    fn test_bytes_since_reseed_tracking() {
+        let mut rng = ReseedableRng::from_os_entropy();
+
+        let mut buf = [0u8; 100];
+        rng.fill_bytes(&mut buf);
+
+        assert_eq!(rng.bytes_since_reseed(), 100);
+    }
+}

--- a/src/reseeding/mod.rs
+++ b/src/reseeding/mod.rs
@@ -1,0 +1,8 @@
+//! CSPRNG reseeding interface.
+//!
+//! This module provides a wrapper around ChaCha-based CSPRNGs
+//! with support for reseeding from conditioned entropy.
+
+mod csprng;
+
+pub use csprng::{ReseedableRng, ReseedingError};


### PR DESCRIPTION
## Summary

This PR establishes the foundational module structure for the optical entropy generation system, following the architecture outlined in the README.

### Changes

- **capture module**: Camera abstraction with trait-based design, frame type with metadata, fixed exposure/gain configuration
- **extraction module**: Temporal differencing to remove static patterns, spatial mixing for decorrelation, raw bitstream types
- **conditioning module**: BLAKE3/SHA-256 hash-based entropy conditioning, accumulator pool with configurable thresholds
- **reseeding module**: ChaCha20-based CSPRNG wrapper with reseed interface that mixes (not replaces) existing state
- **analysis module**: Statistical tests (bias, variance, autocorrelation), quality thresholds, fail-closed health monitoring

### Design Notes

- Strict `deny(unsafe_code)` in lib.rs - all core logic is safe Rust
- Fail-closed behavior: reseeding is gated by health checks passing
- Conservative entropy estimates throughout the pipeline
- Mock camera implementation enables testing without hardware
- All modules include unit tests for core functionality

### Data Flow

```
capture ? extraction ? conditioning ? reseeding
    ?          ?            ?
          analysis (health monitoring)
```

## Test Plan

- [ ] Run `cargo check` to verify compilation
- [ ] Run `cargo test` to verify unit tests pass
- [ ] Run `cargo clippy` for lint checks
- [ ] Review module structure matches README architecture