### PR TITLE
Fix reseeding to use BLAKE3 mixing instead of XOR

### DIFF
--- a/src/conditioning/hash.rs
+++ b/src/conditioning/hash.rs
@@ -41,6 +41,18 @@ impl ConditionedSeed {
     pub fn entropy_estimate(&self) -> usize {
         self.entropy_estimate
     }
+
+    /// Creates a seed for testing purposes only.
+    ///
+    /// This bypasses the normal conditioning pipeline and should
+    /// never be used in production code.
+    #[cfg(test)]
+    pub(crate) fn new_for_testing(data: [u8; 32], entropy_estimate: usize) -> Self {
+        Self {
+            data,
+            entropy_estimate,
+        }
+    }
 }
 
 impl std::fmt::Debug for ConditionedSeed {

--- a/src/reseeding/csprng.rs
+++ b/src/reseeding/csprng.rs
@@ -2,11 +2,27 @@
 //!
 //! Wraps the standard ChaCha20 CSPRNG with an interface for
 //! reseeding from conditioned optical entropy.
+//!
+//! # Reseeding Model
+//!
+//! Reseeding uses BLAKE3 to mix:
+//! - Previous seed material (retained across reseeds)
+//! - New conditioned entropy
+//! - A domain separator and reseed counter
+//!
+//! This follows NIST SP 800-90A style DRBG reseeding logic:
+//! non-linear mixing via a cryptographic hash ensures that
+//! biased or partially predictable inputs cannot degrade security.
 
+use blake3::Hasher;
 use crate::conditioning::ConditionedSeed;
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 use thiserror::Error;
+
+/// Domain separator for reseeding operations.
+/// Ensures the hash context is distinct from other uses.
+const RESEED_DOMAIN: &[u8] = b"optical-entropy-reseed-v1";
 
 /// Errors that can occur during reseeding.
 #[derive(Debug, Error)]
@@ -21,9 +37,19 @@ pub enum ReseedingError {
 /// for periodic reseeding from optical entropy. The CSPRNG is
 /// initialized from OS entropy and can be reseeded with conditioned
 /// optical entropy to supplement (not replace) the initial seed.
+///
+/// # Security Model
+///
+/// - Initial seed comes from OS entropy (trusted)
+/// - Optical entropy is mixed in via BLAKE3 (non-linear, analyzed)
+/// - Previous seed material is retained and mixed with new entropy
+/// - Compromising only the optical source cannot predict outputs
 pub struct ReseedableRng {
     /// The underlying ChaCha20 CSPRNG.
     inner: ChaCha20Rng,
+    /// Retained seed material for mixing during reseed.
+    /// This is NOT the ChaCha internal state.
+    seed_material: [u8; 32],
     /// Minimum entropy required for reseeding.
     min_entropy_bits: usize,
     /// Total reseeds performed.
@@ -39,8 +65,13 @@ impl ReseedableRng {
     /// Optical entropy is used to *supplement* this initial seed,
     /// not replace it.
     pub fn from_os_entropy() -> Self {
+        // Get initial seed from OS
+        let mut seed_material = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed_material);
+
         Self {
-            inner: ChaCha20Rng::from_entropy(),
+            inner: ChaCha20Rng::from_seed(seed_material),
+            seed_material,
             min_entropy_bits: 128,
             reseed_count: 0,
             bytes_since_reseed: 0,
@@ -55,11 +86,30 @@ impl ReseedableRng {
         }
     }
 
+    /// Creates a CSPRNG from a known seed (for testing only).
+    #[cfg(test)]
+    pub(crate) fn from_seed_for_testing(seed: [u8; 32]) -> Self {
+        Self {
+            inner: ChaCha20Rng::from_seed(seed),
+            seed_material: seed,
+            min_entropy_bits: 128,
+            reseed_count: 0,
+            bytes_since_reseed: 0,
+        }
+    }
+
     /// Reseeds the CSPRNG with conditioned optical entropy.
     ///
-    /// The new seed is mixed with the current state rather than
-    /// replacing it entirely, ensuring that compromising the
-    /// optical source alone cannot predict outputs.
+    /// The new seed is derived by hashing together:
+    /// - The previous seed material
+    /// - The new conditioned entropy
+    /// - A domain separator and reseed counter
+    ///
+    /// This ensures:
+    /// - Non-linear mixing (hash, not XOR)
+    /// - Bias resistance (hash output is uniform)
+    /// - Forward secrecy properties are maintained
+    /// - Compromising optical source alone cannot predict outputs
     pub fn reseed(&mut self, seed: &ConditionedSeed) -> Result<(), ReseedingError> {
         if seed.entropy_estimate() < self.min_entropy_bits {
             return Err(ReseedingError::InsufficientEntropy {
@@ -68,24 +118,26 @@ impl ReseedableRng {
             });
         }
 
-        // Mix new seed with current state by XORing
-        // This ensures optical entropy supplements, not replaces
-        let mut current_state = [0u8; 32];
-        self.inner.fill_bytes(&mut current_state);
+        // Mix using BLAKE3:
+        // new_seed = BLAKE3(domain || counter || old_seed_material || new_entropy)
+        let mut hasher = Hasher::new();
+        hasher.update(RESEED_DOMAIN);
+        hasher.update(&self.reseed_count.to_le_bytes());
+        hasher.update(&self.seed_material);
+        hasher.update(seed.as_bytes());
 
-        let mut mixed_seed = [0u8; 32];
-        for i in 0..32 {
-            mixed_seed[i] = current_state[i] ^ seed.as_bytes()[i];
-        }
+        let new_seed_material: [u8; 32] = *hasher.finalize().as_bytes();
 
-        self.inner = ChaCha20Rng::from_seed(mixed_seed);
+        // Update state
+        self.seed_material = new_seed_material;
+        self.inner = ChaCha20Rng::from_seed(new_seed_material);
         self.reseed_count += 1;
         self.bytes_since_reseed = 0;
 
         tracing::info!(
             reseed_count = self.reseed_count,
             entropy_estimate = seed.entropy_estimate(),
-            "CSPRNG reseeded"
+            "CSPRNG reseeded via BLAKE3 mixing"
         );
 
         Ok(())
@@ -128,12 +180,8 @@ impl RngCore for ReseedableRng {
 mod tests {
     use super::*;
 
-    fn make_test_seed(entropy: usize) -> ConditionedSeed {
-        // Create a seed with specified entropy estimate
-        // This is a test helper - in production, seeds come from conditioning
-        let data = [0x42u8; 32];
-        // Use a simple struct construction for testing
-        unsafe { std::mem::transmute((data, entropy)) }
+    fn make_test_seed(data: [u8; 32], entropy: usize) -> ConditionedSeed {
+        ConditionedSeed::new_for_testing(data, entropy)
     }
 
     #[test]
@@ -141,8 +189,7 @@ mod tests {
         let mut rng = ReseedableRng::with_min_entropy(64);
         assert_eq!(rng.reseed_count(), 0);
 
-        // Create a mock seed with sufficient entropy
-        let seed = make_test_seed(128);
+        let seed = make_test_seed([0x42u8; 32], 128);
         rng.reseed(&seed).unwrap();
 
         assert_eq!(rng.reseed_count(), 1);
@@ -152,7 +199,7 @@ mod tests {
     fn test_insufficient_entropy_rejected() {
         let mut rng = ReseedableRng::with_min_entropy(256);
 
-        let seed = make_test_seed(128);
+        let seed = make_test_seed([0x42u8; 32], 128);
         let result = rng.reseed(&seed);
 
         assert!(matches!(
@@ -169,5 +216,74 @@ mod tests {
         rng.fill_bytes(&mut buf);
 
         assert_eq!(rng.bytes_since_reseed(), 100);
+    }
+
+    #[test]
+    fn test_reseed_changes_output() {
+        let initial_seed = [0x01u8; 32];
+        let mut rng1 = ReseedableRng::from_seed_for_testing(initial_seed);
+        let mut rng2 = ReseedableRng::from_seed_for_testing(initial_seed);
+
+        // Before reseed: same output
+        let mut out1 = [0u8; 32];
+        let mut out2 = [0u8; 32];
+        rng1.fill_bytes(&mut out1);
+        rng2.fill_bytes(&mut out2);
+        assert_eq!(out1, out2);
+
+        // Reseed rng1 only
+        let new_entropy = make_test_seed([0xAB; 32], 256);
+        rng1.reseed(&new_entropy).unwrap();
+
+        // After reseed: different output
+        rng1.fill_bytes(&mut out1);
+        rng2.fill_bytes(&mut out2);
+        assert_ne!(out1, out2);
+    }
+
+    #[test]
+    fn test_different_entropy_different_result() {
+        let initial_seed = [0x01u8; 32];
+        let mut rng1 = ReseedableRng::from_seed_for_testing(initial_seed);
+        let mut rng2 = ReseedableRng::from_seed_for_testing(initial_seed);
+
+        let entropy1 = make_test_seed([0xAA; 32], 256);
+        let entropy2 = make_test_seed([0xBB; 32], 256);
+
+        rng1.reseed(&entropy1).unwrap();
+        rng2.reseed(&entropy2).unwrap();
+
+        let mut out1 = [0u8; 32];
+        let mut out2 = [0u8; 32];
+        rng1.fill_bytes(&mut out1);
+        rng2.fill_bytes(&mut out2);
+
+        assert_ne!(out1, out2);
+    }
+
+    #[test]
+    fn test_reseed_counter_affects_output() {
+        // Same entropy applied at different reseed counts should differ
+        let initial_seed = [0x01u8; 32];
+        let mut rng1 = ReseedableRng::from_seed_for_testing(initial_seed);
+        let mut rng2 = ReseedableRng::from_seed_for_testing(initial_seed);
+
+        let entropy = make_test_seed([0xAA; 32], 256);
+        let dummy = make_test_seed([0x00; 32], 256);
+
+        // rng1: reseed once
+        rng1.reseed(&entropy).unwrap();
+
+        // rng2: reseed twice (with dummy first)
+        rng2.reseed(&dummy).unwrap();
+        rng2.reseed(&entropy).unwrap();
+
+        // Even though final entropy is same, counter differs
+        let mut out1 = [0u8; 32];
+        let mut out2 = [0u8; 32];
+        rng1.fill_bytes(&mut out1);
+        rng2.fill_bytes(&mut out2);
+
+        assert_ne!(out1, out2);
     }
 }


### PR DESCRIPTION
## Problem

The initial reseeding implementation had two cryptographic issues:

### 1. Used ChaCha OUTPUT as if it were internal state

```rust
let mut current_state = [0u8; 32];
self.inner.fill_bytes(&mut current_state);  // This is OUTPUT, not state
```

ChaCha is designed so output does not reveal state. Using output as a stand-in for state mixing steps outside the analyzed security model.

### 2. Used XOR for entropy mixing

```rust
mixed_seed[i] = current_state[i] ^ seed.as_bytes()[i];
```

XOR is linear and fragile. If external entropy is biased or partially predictable, XOR does nothing to fix that.

## Solution

Use BLAKE3 hash-based mixing following NIST SP 800-90A DRBG patterns:

```rust
new_seed = BLAKE3(
    domain_separator ||
    reseed_counter ||
    previous_seed_material ||
    new_conditioned_entropy
)
```

This provides:
- **Non-linear mixing** via cryptographic hash
- **Bias resistance** - hash output is uniform regardless of input quality
- **Domain separation** - prevents cross-protocol attacks
- **Replay resistance** - counter ensures same entropy at different times produces different results

## Changes

- Added `seed_material: [u8; 32]` field to retain previous seed (not ChaCha output)
- Replaced XOR with BLAKE3 hash mixing
- Added domain separator constant `optical-entropy-reseed-v1`
- Replaced unsafe `transmute` in tests with proper `new_for_testing()` constructor
- Added tests for reseed behavior

## Test Plan

- [x] `test_reseed_changes_output` - verifies reseed actually changes RNG output
- [x] `test_different_entropy_different_result` - different entropy produces different output
- [x] `test_reseed_counter_affects_output` - counter prevents replay